### PR TITLE
Add Early Access channel support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ LABEL org.opencontainers.image.title="RoonServer"
 LABEL org.opencontainers.image.authors="Roon Labs"
 LABEL org.opencontainers.image.vendor="Roon Labs"
 LABEL org.opencontainers.image.version="${VERSION}"
-LABEL org.opencontainers.image.description="Official Roon Server Docker Image"
+LABEL org.opencontainers.image.description="Official RoonServer Docker Image"
 LABEL org.opencontainers.image.source="https://github.com/RoonLabs/roon-docker"
 LABEL org.opencontainers.image.revision="${GIT_SHA}"
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
@@ -70,6 +70,6 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
 STOPSIGNAL SIGTERM
 
 # entrypoint.sh downloads RoonServer on first run (to /Roon/app), then
-# exec's into Server/RoonServer — the stock bash launcher that handles
+# exec's into start.sh — the stock bash launcher that handles
 # .NET runtime discovery, ulimit, self-update swap, and restart (exit 122).
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RoonServer Docker Image
 
-Official Docker image for [Roon Server](https://roon.app).
+Official Docker image for [RoonServer](https://roon.app).
 
 ```
 ghcr.io/roonlabs/roonserver
@@ -39,6 +39,7 @@ Set the `TZ` environment variable to your [timezone](https://en.wikipedia.org/wi
 | `TZ` | `UTC` | Timezone for logs and schedules |
 | `ROON_DATAROOT` | `/Roon/data` | Data directory (set in image, don't change) |
 | `ROON_ID_DIR` | `/Roon/data` | Identity directory (set in image, don't change) |
+| `ROON_CHANNEL` | `production` | Release channel: `production` or `earlyaccess` |
 | `ROON_DOWNLOAD_URL` | *(default CDN)* | Override the RoonServer download URL |
 
 ## Volumes
@@ -57,19 +58,31 @@ All Roon state lives under a single `/Roon` mount:
 -v /Music:/music:ro
 ```
 
-**The `/Roon/data` directory is critical.** It contains your Roon identity, database, library, playlists, DSP settings, streaming credentials, and zone configurations. If this volume is lost:
+**The `/Roon/data` directory is critical.** If this volume is lost:
 
-- Roon generates a new machine identity — you must re-authorize from a Roon remote
-- Your old machine may consume a license seat until deauthorized (via [account settings](https://accounts.roonlabs.com))
-- All library data, playlists, and settings are lost unless restored from a Roon backup
+- Your Roon data and settings are lost unless they can be restored from a Roon backup
+- The server will appear as a new machine and must be re-authorized from a Roon remote
 
-Always back up your `/Roon` volume. Use the Roon backup feature (Settings > Backups) pointed at `/Roon/backup`.
+Always back up your /Roon volume. We recommend using Roon's built-in backup feature in Settings > Backups, with /Roon/backup as the backup destination
 
 ## Updating
 
-Roon Server updates itself automatically. When an update is available, the container will download and apply it — no action needed.
+RoonServer updates itself automatically. When an update is available, the container will download and apply it — no action needed.
 
-Updates persist across `docker stop` / `docker start`. If you recreate the container (`docker rm` + `docker run`), Roon will re-download the latest version on first start.
+Updates persist across `docker stop` / `docker start`. If you recreate the container (`docker rm` + `docker run`), RoonServer will be re-downloaded from the configured release channel on first start.
+
+## Release Channel
+
+RoonServer has two release channels:
+
+| Channel | `ROON_CHANNEL` | Community |
+|---------|----------------|-----------|
+| **Production** | `production` (default) | [Roon](https://community.roonlabs.com/c/roon/8) |
+| **Early Access** | `earlyaccess` | [Early Access](https://community.roonlabs.com/c/early-access/120) |
+
+Set `ROON_CHANNEL` to change the channel. The channel determines which version of RoonServer is downloaded on first start, and Roon's self-updater continues on the same channel automatically.
+
+Changing channels on an existing install is safe — the container removes the old binaries and downloads from the new channel. Your data, settings, and identity are preserved.
 
 ## Troubleshooting
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,24 @@ set -euo pipefail
 
 ROON_APP_DIR="/Roon/app"
 ROON_INSTALLED="${ROON_APP_DIR}/.installed"
-ROON_DOWNLOAD_URL="${ROON_DOWNLOAD_URL:-https://download.roonlabs.net/builds/RoonServer_linuxx64.tar.bz2}"
+ROON_CHANNEL_FILE="${ROON_APP_DIR}/.channel"
+
+# Channel selection: production (default) or earlyaccess.
+# If a channel file exists from a previous install and the user hasn't explicitly
+# set ROON_CHANNEL, honor the existing channel to avoid unwanted downgrades.
+if [ -z "${ROON_CHANNEL+x}" ] && [ -f "$ROON_CHANNEL_FILE" ]; then
+    ROON_CHANNEL="$(cat "$ROON_CHANNEL_FILE")"
+fi
+ROON_CHANNEL="${ROON_CHANNEL:-production}"
+ROON_CHANNEL="$(echo "$ROON_CHANNEL" | tr '[:upper:]' '[:lower:]')"
+
+case "$ROON_CHANNEL" in
+    production)  _DEFAULT_URL="https://download.roonlabs.net/builds/RoonServer_linuxx64.tar.bz2" ;;
+    earlyaccess) _DEFAULT_URL="https://download.roonlabs.net/builds/earlyaccess/RoonServer_linuxx64.tar.bz2" ;;
+    *) echo "Invalid ROON_CHANNEL='$ROON_CHANNEL'. Must be 'production' or 'earlyaccess'."; exit 1 ;;
+esac
+
+ROON_DOWNLOAD_URL="${ROON_DOWNLOAD_URL:-$_DEFAULT_URL}"
 
 # Verify /Roon is mounted and writable
 if test ! -w /Roon; then
@@ -13,6 +30,25 @@ fi
 
 # Ensure directory structure exists
 mkdir -p /Roon/{app,data,backup}
+
+# Detect channel switch on existing install
+if [ -f "$ROON_INSTALLED" ] && [ -f "$ROON_CHANNEL_FILE" ]; then
+    INSTALLED_CHANNEL="$(cat "$ROON_CHANNEL_FILE")"
+    if [ "$INSTALLED_CHANNEL" != "$ROON_CHANNEL" ]; then
+        echo "Channel change detected: $INSTALLED_CHANNEL -> $ROON_CHANNEL"
+        echo "Removing old RoonServer binaries..."
+        rm -rf "${ROON_APP_DIR}/RoonServer"
+        rm -f "$ROON_INSTALLED" "$ROON_CHANNEL_FILE"
+    fi
+fi
+
+# Upgrade path: existing install from pre-channel image (no .channel file).
+# If ROON_CHANNEL is explicitly set to something other than production, force reinstall.
+if [ -f "$ROON_INSTALLED" ] && [ ! -f "$ROON_CHANNEL_FILE" ] && [ "$ROON_CHANNEL" != "production" ]; then
+    echo "No channel file found — reinstalling for $ROON_CHANNEL channel..."
+    rm -rf "${ROON_APP_DIR}/RoonServer"
+    rm -f "$ROON_INSTALLED"
+fi
 
 # Download and install RoonServer on first run
 if [ ! -f "$ROON_INSTALLED" ]; then
@@ -32,12 +68,20 @@ if [ ! -f "$ROON_INSTALLED" ]; then
     else
         echo "unknown" > "$ROON_INSTALLED"
     fi
+
+    echo "$ROON_CHANNEL" > "$ROON_CHANNEL_FILE"
     echo "RoonServer installed successfully."
 fi
 
+# Backfill channel file for pre-channel installs that are staying on production
+if [ ! -f "$ROON_CHANNEL_FILE" ]; then
+    echo "$ROON_CHANNEL" > "$ROON_CHANNEL_FILE"
+fi
+
 # Log versions at startup
-echo "Image: $(cat /etc/roon-image-version 2>/dev/null || echo 'unknown')"
-echo "Roon:  $(sed -n '2p' "$ROON_INSTALLED" 2>/dev/null || echo 'unknown')"
+echo "Image:   $(cat /etc/roon-image-version 2>/dev/null || echo 'unknown')"
+echo "Channel: $ROON_CHANNEL"
+echo "Roon:    $(sed -n '2p' "$ROON_INSTALLED" 2>/dev/null || echo 'unknown')"
 
 # start.sh handles restart-on-exit-122 without a full container restart
 exec "${ROON_APP_DIR}/RoonServer/start.sh"

--- a/index.html
+++ b/index.html
@@ -54,6 +54,18 @@
   /* Editor dots */
   .editor-dot { width: 12px; height: 12px; border-radius: 50%; }
 
+  /* Tooltip */
+  [data-tooltip] { position: relative; }
+  [data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute; bottom: 100%; left: 50%; transform: translateX(-50%);
+    padding: 4px 8px; margin-bottom: 6px;
+    background: #1a202b; color: #e2e8f0; border: 1px solid #374151;
+    border-radius: 6px; font-size: 12px; white-space: nowrap;
+    opacity: 0; pointer-events: none; transition: opacity 0.15s;
+  }
+  [data-tooltip]:hover::after { opacity: 1; }
+
   /* Reduced motion */
   @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
@@ -103,7 +115,7 @@
 
         <!-- Platform Selector -->
         <section class="bg-surface-800/60 border border-surface-500/40 rounded-xl p-5 backdrop-blur-sm">
-          <h3 class="text-xs font-semibold uppercase tracking-wider text-surface-300 mb-3">Platform</h3>
+          <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-200 mb-3">Platform</h3>
           <label for="platform-select" class="sr-only">Select your platform</label>
           <select id="platform-select"
                   class="w-full px-3 py-2 bg-surface-700 border border-surface-500/50 rounded-lg text-sm text-slate-200 focus:border-roon-400 focus:ring-1 focus:ring-roon-400 transition-colors duration-200 outline-none appearance-none"
@@ -118,17 +130,18 @@
           <p class="text-xs text-surface-300 mt-3" id="platform-hint" aria-live="polite">Paths set to standard Linux conventions.</p>
         </section>
 
-        <!-- Image -->
+        <!-- Release Channel -->
         <section class="bg-surface-800/60 border border-surface-500/40 rounded-xl p-5 backdrop-blur-sm">
-          <h3 class="text-xs font-semibold uppercase tracking-wider text-surface-300 mb-3">Image</h3>
+          <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-200 mb-3">Roon Server Release Channel</h3>
           <div>
-            <label class="block text-xs text-surface-300 mb-1.5" for="image">Container image tag</label>
-            <select id="image"
-                    class="w-full px-3 py-2 bg-surface-700 border border-surface-500/50 rounded-lg text-sm font-mono text-slate-200 focus:border-roon-400 focus:ring-1 focus:ring-roon-400 transition-colors duration-200 outline-none appearance-none"
+            <label class="block text-xs text-surface-300 mb-1.5" for="channel-select">Which release channel to install on first start</label>
+            <select id="channel-select"
+                    class="w-full px-3 py-2 bg-surface-700 border border-surface-500/50 rounded-lg text-sm text-slate-200 focus:border-roon-400 focus:ring-1 focus:ring-roon-400 transition-colors duration-200 outline-none appearance-none"
                     style="background-image:url('data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2212%22%20height%3D%2212%22%20viewBox%3D%220%200%2012%2012%22%3E%3Cpath%20fill%3D%22%236b7280%22%20d%3D%22M3%204.5l3%203%203-3%22%2F%3E%3C%2Fsvg%3E');background-repeat:no-repeat;background-position:right 12px center;padding-right:36px">
-              <option value="ghcr.io/roonlabs/roonserver:latest" selected>latest</option>
+              <option value="production" selected>Production</option>
+              <option value="earlyaccess">Early Access</option>
             </select>
-            <p class="text-xs text-surface-300 mt-1.5" id="image-hint"></p>
+            <p class="text-xs text-surface-300 mt-1.5" id="channel-hint"></p>
           </div>
         </section>
 
@@ -136,10 +149,10 @@
         <section class="bg-surface-800/60 border border-surface-500/40 rounded-xl p-5 backdrop-blur-sm">
           <div class="flex items-center justify-between mb-4">
             <div class="flex items-center gap-2">
-              <h3 class="text-xs font-semibold uppercase tracking-wider text-surface-300">Volumes</h3>
+              <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-200">Volumes</h3>
               <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider bg-red-500/15 text-red-400 ring-1 ring-red-500/20">Required</span>
             </div>
-            <button type="button" id="btn-add-volume" aria-label="Add volume mount"
+            <button type="button" id="btn-add-volume" data-tooltip="Add volume mount" aria-label="Add volume mount"
                     class="inline-flex items-center justify-center w-7 h-7 text-surface-300 hover:text-white bg-surface-700/60 hover:bg-surface-600/80 border border-surface-500/40 hover:border-roon-400/50 rounded-lg transition-all duration-200">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg>
             </button>
@@ -166,7 +179,7 @@
 
         <!-- Options -->
         <section class="bg-surface-800/60 border border-surface-500/40 rounded-xl p-5 backdrop-blur-sm">
-          <h3 class="text-xs font-semibold uppercase tracking-wider text-surface-300 mb-4">Options</h3>
+          <h3 class="text-xs font-semibold uppercase tracking-wider text-slate-200 mb-4">Options</h3>
           <div class="space-y-0">
 
             <!-- Timezone -->
@@ -292,7 +305,7 @@
               </button>
             </div>
             <div class="flex gap-1.5">
-              <button id="btn-copy" aria-label="Copy to clipboard"
+              <button id="btn-copy" data-tooltip="Copy to clipboard" aria-label="Copy to clipboard"
                       class="inline-flex items-center justify-center w-8 h-8 bg-surface-700/60 hover:bg-surface-600/80 border border-surface-500/40 hover:border-roon-400/50 rounded-lg text-surface-300 hover:text-white transition-all duration-200 active:scale-95">
                 <svg id="icon-copy" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
                   <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
@@ -302,7 +315,7 @@
                   <polyline points="20 6 9 17 4 12"></polyline>
                 </svg>
               </button>
-              <button id="btn-download" aria-label="Download file"
+              <button id="btn-download" data-tooltip="Download as file" aria-label="Download file"
                       class="inline-flex items-center justify-center w-8 h-8 bg-surface-700/60 hover:bg-surface-600/80 border border-surface-500/40 hover:border-roon-400/50 rounded-lg text-surface-300 hover:text-white transition-all duration-200 active:scale-95">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
@@ -410,7 +423,8 @@
     });
 
     return {
-      image: getVal('image') || 'ghcr.io/roonlabs/roonserver:latest',
+      image: 'ghcr.io/roonlabs/roonserver:latest',
+      channel: getVal('channel-select') || 'production',
       volRoon: getVal('vol-roon') || '/Roon',
       volMusic: getVal('vol-music') || '/music',
       extraVolumes: extras,
@@ -434,9 +448,12 @@
     lines.push('    network_mode: host');
     lines.push('    init: true');
 
-    if (cfg.tz) {
+    var envVars = [];
+    if (cfg.channel === 'earlyaccess') envVars.push('ROON_CHANNEL=earlyaccess');
+    if (cfg.tz) envVars.push('TZ=' + cfg.tzValue);
+    if (envVars.length) {
       lines.push('    environment:');
-      lines.push('      - TZ=' + cfg.tzValue);
+      envVars.forEach(function(v) { lines.push('      - ' + v); });
     }
 
     lines.push('    volumes:');
@@ -491,6 +508,9 @@
     parts.push('  --network host \\');
     parts.push('  --init \\');
 
+    if (cfg.channel === 'earlyaccess') {
+      parts.push('  -e ROON_CHANNEL=earlyaccess \\');
+    }
     if (cfg.tz) {
       parts.push('  -e TZ=' + cfg.tzValue + ' \\');
     }
@@ -846,6 +866,7 @@
     var removeBtn = document.createElement('button');
     removeBtn.type = 'button';
     removeBtn.setAttribute('aria-label', 'Remove volume mount');
+    removeBtn.setAttribute('data-tooltip', 'Remove volume mount');
     removeBtn.className = 'inline-flex items-center justify-center w-6 h-6 text-surface-300 hover:text-red-400 transition-colors duration-200 rounded';
     var svgNS = 'http://www.w3.org/2000/svg';
     var svg = document.createElementNS(svgNS, 'svg');
@@ -909,7 +930,11 @@
 
   document.getElementById('tz-value').addEventListener('change', generate);
 
-  document.getElementById('image').addEventListener('change', generate);
+  document.getElementById('channel-select').addEventListener('change', function() {
+    var hint = document.getElementById('channel-hint');
+    hint.textContent = this.value === 'earlyaccess' ? 'Early access to new features and updates.' : '';
+    generate();
+  });
 
   ['opt-tz', 'opt-logging', 'opt-grace', 'opt-cifs', 'opt-usb-audio', 'opt-hdmi-audio'].forEach(function(id) {
     document.getElementById(id).addEventListener('change', generate);
@@ -979,40 +1004,6 @@
     });
   })();
 
-  // --- Fetch available image tags from GHCR ---
-  (function fetchTags() {
-    var imageSelect = document.getElementById('image');
-    var imageHint = document.getElementById('image-hint');
-    fetch('https://ghcr.io/v2/roonlabs/roonserver/tags/list')
-      .then(function(res) {
-        if (!res.ok) throw new Error(res.status);
-        return res.json();
-      })
-      .then(function(data) {
-        var tags = (data.tags || []).sort(function(a, b) {
-          // Put 'latest' first, then sort version tags descending
-          if (a === 'latest') return -1;
-          if (b === 'latest') return 1;
-          return b.localeCompare(a, undefined, { numeric: true });
-        });
-        if (tags.length > 1) {
-          // Clear default and rebuild with fetched tags
-          while (imageSelect.firstChild) imageSelect.removeChild(imageSelect.firstChild);
-          tags.forEach(function(tag) {
-            var opt = document.createElement('option');
-            opt.value = 'ghcr.io/roonlabs/roonserver:' + tag;
-            opt.textContent = tag;
-            if (tag === 'latest') opt.selected = true;
-            imageSelect.appendChild(opt);
-          });
-          imageHint.textContent = tags.length + ' versions available';
-        }
-      })
-      .catch(function() {
-        // Registry unavailable or package is private — keep the default "latest" option
-        imageHint.textContent = '';
-      });
-  })();
 
 
   // --- Detect macOS/Windows and show a note ---

--- a/tests/runtime.sh
+++ b/tests/runtime.sh
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
 # Starts the container and validates the download/install/startup flow.
-# This test downloads ~200MB from download.roonlabs.net.
+# Tests production install, EA install, and channel switching.
+# Downloads ~200MB per channel from download.roonlabs.net.
 set -euo pipefail
 
 IMAGE="${1:?Usage: runtime.sh <image:tag>}"
-CONTAINER="roon-runtime-test"
-ROON_DIR="$(mktemp -d)"
 PASS=0
 FAIL=0
-
-cleanup() {
-    docker rm -f "$CONTAINER" 2>/dev/null || true
-    rm -rf "$ROON_DIR"
-}
-trap cleanup EXIT
 
 check() {
     local desc="$1"; shift
@@ -26,25 +19,38 @@ check() {
     fi
 }
 
-echo "=== Runtime tests: $IMAGE ==="
+wait_for_install() {
+    local dir="$1"
+    local timeout="${2:-120}"
+    local elapsed=0
+    echo "    Waiting for RoonServer download..."
+    while [ ! -f "$dir/app/.installed" ] && [ "$elapsed" -lt "$timeout" ]; do
+        sleep 5
+        elapsed=$((elapsed + 5))
+        echo "    ... ${elapsed}s"
+    done
+}
+
+# ─── Production channel ────────────────────────────────────────
+
+echo "=== Runtime tests (production): $IMAGE ==="
+
+CONTAINER="roon-runtime-production"
+ROON_DIR="$(mktemp -d)"
 echo "    Temp dir: $ROON_DIR"
 
-# Start container — entrypoint will download RoonServer
+cleanup_production() {
+    docker rm -f "$CONTAINER" 2>/dev/null || true
+    rm -rf "$ROON_DIR"
+}
+trap cleanup_production EXIT
+
 docker run -d --name "$CONTAINER" \
     -v "$ROON_DIR:/Roon" \
     "$IMAGE"
 
-# Wait for download and extraction (timeout after 120s)
-echo "    Waiting for RoonServer download..."
-TIMEOUT=120
-ELAPSED=0
-while [ ! -f "$ROON_DIR/app/.installed" ] && [ "$ELAPSED" -lt "$TIMEOUT" ]; do
-    sleep 5
-    ELAPSED=$((ELAPSED + 5))
-    echo "    ... ${ELAPSED}s"
-done
+wait_for_install "$ROON_DIR"
 
-# Check results
 check "sentinel file created" \
     test -f "$ROON_DIR/app/.installed"
 
@@ -69,21 +75,222 @@ check "VERSION file present in tarball" \
 check "libfreetype.so.6 symlink created" \
     test -L "$ROON_DIR/app/RoonServer/Appliance/libfreetype.so.6"
 
-# Grab logs before stopping
 docker logs "$CONTAINER" > "$ROON_DIR/container.log" 2>&1 || true
 
 check "logs contain image version" \
     grep -q "^Image:" "$ROON_DIR/container.log"
 
+check "logs contain channel" \
+    grep -q "^Channel: production" "$ROON_DIR/container.log"
+
 check "logs contain roon version" \
     grep -q "^Roon:" "$ROON_DIR/container.log"
 
-# Signal handling: docker stop should exit cleanly (0 or 143), not hard-killed (137)
+check "channel sentinel file created" \
+    test -f "$ROON_DIR/app/.channel"
+
+check "channel sentinel contains production" \
+    grep -q "production" "$ROON_DIR/app/.channel"
+
+# Record production version for later comparison
+PROD_VERSION=$(cat "$ROON_DIR/app/.installed" 2>/dev/null || echo "")
+
 echo "    Testing clean shutdown..."
 docker stop -t 30 "$CONTAINER" 2>/dev/null || true
 EXIT_CODE=$(docker inspect "$CONTAINER" --format '{{.State.ExitCode}}')
 check "clean shutdown (exit 0 or 143, got $EXIT_CODE)" \
     test "$EXIT_CODE" -eq 0 -o "$EXIT_CODE" -eq 143
+
+cleanup_production
+trap - EXIT
+
+# ─── Channel switch: production → earlyaccess ─────────────────
+
+echo ""
+echo "=== Runtime tests (channel switch → earlyaccess): $IMAGE ==="
+
+CONTAINER="roon-runtime-switch"
+ROON_DIR="$(mktemp -d)"
+echo "    Temp dir: $ROON_DIR"
+
+cleanup_switch() {
+    docker rm -f "$CONTAINER" 2>/dev/null || true
+    rm -rf "$ROON_DIR"
+}
+trap cleanup_switch EXIT
+
+# First: install production
+docker run -d --name "$CONTAINER" \
+    -v "$ROON_DIR:/Roon" \
+    "$IMAGE"
+
+wait_for_install "$ROON_DIR"
+docker stop -t 10 "$CONTAINER" 2>/dev/null || true
+docker rm -f "$CONTAINER" 2>/dev/null || true
+
+check "production installed before switch" \
+    grep -q "production" "$ROON_DIR/app/.channel"
+
+# Now: switch to earlyaccess
+# The entrypoint detects .channel=production vs ROON_CHANNEL=earlyaccess, removes old binaries,
+# and re-downloads. We wait for .channel to change to earlyaccess as the completion signal.
+docker run -d --name "$CONTAINER" \
+    -v "$ROON_DIR:/Roon" \
+    -e ROON_CHANNEL=earlyaccess \
+    "$IMAGE"
+
+echo "    Waiting for channel switch..."
+TIMEOUT=180
+ELAPSED=0
+while ! grep -q "earlyaccess" "$ROON_DIR/app/.channel" 2>/dev/null && [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+    echo "    ... ${ELAPSED}s"
+done
+
+docker logs "$CONTAINER" > "$ROON_DIR/switch.log" 2>&1 || true
+
+check "logs show channel change detected" \
+    grep -q "Channel change detected" "$ROON_DIR/switch.log"
+
+check "channel sentinel updated to earlyaccess" \
+    grep -q "earlyaccess" "$ROON_DIR/app/.channel"
+
+check "logs show earlyaccess channel" \
+    grep -q "^Channel: earlyaccess" "$ROON_DIR/switch.log"
+
+check "RoonServer reinstalled after switch" \
+    test -f "$ROON_DIR/app/.installed"
+
+# EA version may differ from production
+EA_VERSION=$(cat "$ROON_DIR/app/.installed" 2>/dev/null || echo "")
+if [ -n "$PROD_VERSION" ] && [ -n "$EA_VERSION" ]; then
+    echo "    Production version: $(echo "$PROD_VERSION" | head -2 | tail -1)"
+    echo "    EA version:     $(echo "$EA_VERSION" | head -2 | tail -1)"
+fi
+
+docker stop -t 10 "$CONTAINER" 2>/dev/null || true
+
+cleanup_switch
+trap - EXIT
+
+# ─── Restart: existing install skips re-download ───────────────
+
+echo ""
+echo "=== Runtime tests (restart skips download): $IMAGE ==="
+
+CONTAINER="roon-runtime-restart"
+ROON_DIR="$(mktemp -d)"
+echo "    Temp dir: $ROON_DIR"
+
+cleanup_restart() {
+    docker rm -f "$CONTAINER" 2>/dev/null || true
+    rm -rf "$ROON_DIR"
+}
+trap cleanup_restart EXIT
+
+# Install production first
+docker run -d --name "$CONTAINER" \
+    -v "$ROON_DIR:/Roon" \
+    "$IMAGE"
+
+wait_for_install "$ROON_DIR"
+docker stop -t 10 "$CONTAINER" 2>/dev/null || true
+docker rm -f "$CONTAINER" 2>/dev/null || true
+
+# Restart — should NOT re-download
+docker run -d --name "$CONTAINER" \
+    -v "$ROON_DIR:/Roon" \
+    "$IMAGE"
+
+# Give it a few seconds to start
+sleep 5
+
+docker logs "$CONTAINER" > "$ROON_DIR/restart.log" 2>&1 || true
+
+check "restart does not re-download" \
+    sh -c '! grep -q "downloading" "$1"' _ "$ROON_DIR/restart.log"
+
+check "restart logs channel" \
+    grep -q "^Channel: production" "$ROON_DIR/restart.log"
+
+docker stop -t 10 "$CONTAINER" 2>/dev/null || true
+
+cleanup_restart
+trap - EXIT
+
+# ─── Pre-channel upgrade: .installed exists, no .channel ───────
+
+echo ""
+echo "=== Runtime tests (pre-channel upgrade): $IMAGE ==="
+
+CONTAINER="roon-runtime-upgrade"
+ROON_DIR="$(mktemp -d)"
+echo "    Temp dir: $ROON_DIR"
+
+cleanup_upgrade() {
+    docker rm -f "$CONTAINER" 2>/dev/null || true
+    rm -rf "$ROON_DIR"
+}
+trap cleanup_upgrade EXIT
+
+# Install production first
+docker run -d --name "$CONTAINER" \
+    -v "$ROON_DIR:/Roon" \
+    "$IMAGE"
+
+wait_for_install "$ROON_DIR"
+docker stop -t 10 "$CONTAINER" 2>/dev/null || true
+docker rm -f "$CONTAINER" 2>/dev/null || true
+
+# Simulate pre-channel image: remove .channel but keep .installed
+rm -f "$ROON_DIR/app/.channel"
+
+# Restart without setting ROON_CHANNEL — should default to production and backfill .channel
+docker run -d --name "$CONTAINER" \
+    -v "$ROON_DIR:/Roon" \
+    "$IMAGE"
+
+sleep 5
+
+check "backfills .channel on pre-channel install" \
+    test -f "$ROON_DIR/app/.channel"
+
+check "backfilled channel is production" \
+    grep -q "production" "$ROON_DIR/app/.channel"
+
+docker logs "$CONTAINER" > "$ROON_DIR/upgrade.log" 2>&1 || true
+
+check "pre-channel restart does not re-download" \
+    sh -c '! grep -q "downloading" "$1"' _ "$ROON_DIR/upgrade.log"
+
+docker stop -t 10 "$CONTAINER" 2>/dev/null || true
+docker rm -f "$CONTAINER" 2>/dev/null || true
+
+# Now simulate: pre-channel install + user wants EA
+rm -f "$ROON_DIR/app/.channel"
+
+docker run -d --name "$CONTAINER" \
+    -v "$ROON_DIR:/Roon" \
+    -e ROON_CHANNEL=earlyaccess \
+    "$IMAGE"
+
+echo "    Waiting for EA reinstall..."
+TIMEOUT=180
+ELAPSED=0
+while ! grep -q "earlyaccess" "$ROON_DIR/app/.channel" 2>/dev/null && [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+    echo "    ... ${ELAPSED}s"
+done
+
+check "pre-channel install switches to EA when requested" \
+    grep -q "earlyaccess" "$ROON_DIR/app/.channel"
+
+docker stop -t 10 "$CONTAINER" 2>/dev/null || true
+
+cleanup_upgrade
+trap - EXIT
 
 echo ""
 echo "=== $PASS passed, $FAIL failed ==="

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -64,6 +64,49 @@ check "exits with error when /Roon not mounted" \
 check "prints writable error when /Roon not mounted" \
     sh -c 'echo "$1" | grep -q "not writable"' _ "$FAIL_OUTPUT"
 
+# Invalid channel should exit with error
+CHAN_EXIT=0
+CHAN_OUTPUT=$(docker run --rm -e ROON_CHANNEL=invalid -v "$(mktemp -d):/Roon" "$IMAGE" 2>&1) || CHAN_EXIT=$?
+check "rejects invalid ROON_CHANNEL" \
+    sh -c 'echo "$1" | grep -q "Invalid ROON_CHANNEL"' _ "$CHAN_OUTPUT"
+
+# Mixed-case channel should be accepted (use bad URL so it fails fast after validation)
+MIXED_EXIT=0
+MIXED_OUTPUT=$(docker run --rm -e ROON_CHANNEL=EarlyAccess -e ROON_DOWNLOAD_URL=http://localhost:1 -v "$(mktemp -d):/Roon" "$IMAGE" 2>&1) || MIXED_EXIT=$?
+check "accepts mixed-case ROON_CHANNEL" \
+    sh -c '! echo "$1" | grep -q "Invalid ROON_CHANNEL"' _ "$MIXED_OUTPUT"
+
+# Empty channel should default to production (use bad URL so it fails fast after validation)
+EMPTY_EXIT=0
+EMPTY_OUTPUT=$(docker run --rm -e ROON_CHANNEL= -e ROON_DOWNLOAD_URL=http://localhost:1 -v "$(mktemp -d):/Roon" "$IMAGE" 2>&1) || EMPTY_EXIT=$?
+check "empty ROON_CHANNEL defaults to production" \
+    sh -c '! echo "$1" | grep -q "Invalid ROON_CHANNEL"' _ "$EMPTY_OUTPUT"
+
+# Read-only /Roon mount should fail with writable error
+RO_EXIT=0
+RO_OUTPUT=$(docker run --rm -v "$(mktemp -d):/Roon:ro" "$IMAGE" 2>&1) || RO_EXIT=$?
+check "exits with error when /Roon is read-only" \
+    test "$RO_EXIT" -ne 0
+
+check "prints writable error when /Roon is read-only" \
+    sh -c 'echo "$1" | grep -q "not writable"' _ "$RO_OUTPUT"
+
+# Bad download URL should fail
+BAD_EXIT=0
+BAD_OUTPUT=$(docker run --rm -e ROON_DOWNLOAD_URL=https://download.roonlabs.net/nonexistent -v "$(mktemp -d):/Roon" "$IMAGE" 2>&1) || BAD_EXIT=$?
+check "exits with error on bad download URL" \
+    test "$BAD_EXIT" -ne 0
+
+# NAS compatibility: required libraries and binaries
+check "mount.cifs binary exists" \
+    docker run --rm --entrypoint which "$IMAGE" mount.cifs
+
+check "libasound is available" \
+    docker run --rm --entrypoint sh "$IMAGE" -c 'ldconfig -p | grep -q libasound'
+
+check "entrypoint uses --no-same-permissions for QNAP" \
+    docker run --rm --entrypoint grep "$IMAGE" -- '--no-same-permissions' /entrypoint.sh
+
 echo ""
 echo "=== $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Add `ROON_CHANNEL` environment variable to select between `production` (default) and `earlyaccess` release channels
- Automatic channel switching on existing installs — removes old binaries and re-downloads from the new channel while preserving all user data
- Honors the previously installed channel on restart when `ROON_CHANNEL` isn't explicitly set, preventing unwanted downgrades
- Handles upgrades from pre-channel images gracefully
- Replace the Image selector in the setup guide with a Release Channel selector (Production / Early Access)
- CSS tooltips, card header contrast improvements, and aria-label coverage for accessibility
- Comprehensive test coverage (49 tests) including channel validation, switching, restart behavior, pre-channel upgrades, NAS compatibility checks, and error paths
