### PR TITLE
Add automatic updating through watchtower

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ To use Roon's database backup feature, mount a volume at `/RoonBackups` and poin
 
 All RoonServer state and binaries are persisted to the `/Roon` volume. Recreating the container (`docker rm` + `docker run`) does not trigger a re-download if you mount in the same folder to the `/Roon` volume.
 
+### Automatic updates via Watchtower
+
+The configuration generator enables [Watchtower](https://github.com/nicholas-fedor/watchtower) by default — a small sidecar that polls the registry daily and recreates the RoonServer container when a newer image is published. It is scoped via the `com.centurylinklabs.watchtower.enable=true` label so only RoonServer is managed; other containers on the host are left alone.
+
+If you prefer manual updates, disable the toggle in the generator or remove the `watchtower` service and label from your compose file. You can then update on demand with:
+
+```
+docker pull ghcr.io/roonlabs/roonserver:latest
+docker rm -f roonserver
+# re-run your docker run command or: docker compose up -d
+```
+
 ## Release Branch
 
 RoonServer has two release branches:

--- a/index.html
+++ b/index.html
@@ -233,6 +233,23 @@
               </div>
             </div>
 
+            <!-- Auto-updates -->
+            <div class="py-3 border-b border-surface-500/30">
+              <div class="flex items-start gap-3">
+                <label class="relative inline-flex items-center cursor-pointer mt-0.5 flex-shrink-0">
+                  <input type="checkbox" id="opt-watchtower" class="sr-only peer" checked>
+                  <div class="toggle-track"></div>
+                </label>
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <label class="text-sm font-medium text-white cursor-pointer" for="opt-watchtower">Auto-update via Watchtower</label>
+                    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider bg-amber-500/15 text-amber-400 ring-1 ring-amber-500/20">Recommended</span>
+                  </div>
+                  <p class="text-xs text-surface-300 mt-0.5">Adds a Watchtower container that checks daily for image updates. Scoped via label so only RoonServer is managed.</p>
+                </div>
+              </div>
+            </div>
+
             <!-- CIFS -->
             <div class="py-3 border-b border-surface-500/30">
               <div class="flex items-start gap-3">
@@ -461,6 +478,7 @@
       tz: isChecked('opt-tz'),
       tzValue: getVal('tz-value'),
       logging: isChecked('opt-logging'),
+      watchtower: isChecked('opt-watchtower'),
       cifs: isChecked('opt-cifs'),
       usbAudio: isChecked('opt-usb-audio'),
       hdmiAudio: isChecked('opt-hdmi-audio'),
@@ -523,6 +541,19 @@
       lines.push('      driver: local');
     }
 
+    if (cfg.watchtower) {
+      lines.push('    labels:');
+      lines.push('      - com.centurylinklabs.watchtower.enable=true');
+      lines.push('');
+      lines.push('  watchtower:');
+      lines.push('    image: nickfedor/watchtower:latest');
+      lines.push('    container_name: watchtower');
+      lines.push('    restart: unless-stopped');
+      lines.push('    volumes:');
+      lines.push('      - /var/run/docker.sock:/var/run/docker.sock');
+      lines.push('    command: --label-enable --cleanup');
+    }
+
     return lines;
   }
 
@@ -571,8 +602,18 @@
       parts.push('  --group-add audio \\');
     }
 
-    // Image as final line (no trailing backslash)
-    parts.push('  ' + cfg.image);
+    if (cfg.watchtower) {
+      parts.push('  --label com.centurylinklabs.watchtower.enable=true \\');
+      parts.push('  ' + cfg.image + ' && \\');
+      parts.push('docker run -d \\');
+      parts.push('  --name watchtower \\');
+      parts.push('  --restart unless-stopped \\');
+      parts.push('  -v /var/run/docker.sock:/var/run/docker.sock \\');
+      parts.push('  nickfedor/watchtower:latest \\');
+      parts.push('  --label-enable --cleanup');
+    } else {
+      parts.push('  ' + cfg.image);
+    }
 
     return parts;
   }
@@ -964,7 +1005,7 @@
     generate();
   });
 
-  ['opt-tz', 'opt-logging', 'opt-cifs', 'opt-usb-audio', 'opt-hdmi-audio'].forEach(function(id) {
+  ['opt-tz', 'opt-logging', 'opt-watchtower', 'opt-cifs', 'opt-usb-audio', 'opt-hdmi-audio'].forEach(function(id) {
     document.getElementById(id).addEventListener('change', generate);
   });
 

--- a/index.html
+++ b/index.html
@@ -1047,7 +1047,7 @@
 
   // --- Initial render ---
   updateNote();
-  generate();
+  setPlatform(document.getElementById('platform-select').value);
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary

- **Adds a default-on Watchtower toggle** in the config generator. When enabled, the compose output appends a `watchtower` service and labels the `roonserver` service with `com.centurylinklabs.watchtower.enable=true` so Watchtower only manages RoonServer — not every container on the host. The `docker run` output chains both containers with `&&` instead of splitting into two blocks.
- **Uses `nickfedor/watchtower`**, a community-maintained fork. The original `containrrr/watchtower` was archived in Dec 2025 and is incompatible with Docker Engine 29+.
- **README** gets a new *Automatic updates via Watchtower* subsection under *Updating*, with a manual-update escape hatch for users who prefer to control upgrades themselves.
- **Bugfix (separate commit):** `setPlatform()` now runs on initial page load so the vol-roon/vol-music/vol-backup input values match the selected platform preset. Before this, the Linux backup field displayed `/RoonBackups` (stale HTML default) instead of `/opt/RoonBackups` from the preset.

## Design decisions

- `--label-enable` + explicit label on `roonserver` → Watchtower leaves other containers alone. Safe default for homelab / NAS users who run mixed container workloads.
- `--cleanup` → removes old image layers after a successful update (prevents multi-GB disk accumulation on NAS; tradeoff is losing the "restart with previous image" rollback).
- Poll interval left at Watchtower default (24h) — frequent enough to catch updates, infrequent enough to avoid surprising restarts.
- Excluded tags `0` and `0.0` on publish so users pinning a floating major/minor don't get unexpected bumps — only `X.Y.Z` + `latest` are published.

## Test plan

- [x] Generator toggle renders and defaults to on
- [x] Compose output with toggle **on**: `watchtower` service present, `com.centurylinklabs.watchtower.enable=true` label on roonserver
- [x] Compose output with toggle **off**: no watchtower service, no label
- [x] `docker run` output with toggle on: two `docker run` commands chained with `&&`
- [x] Initial page load shows platform-preset paths (not stale HTML defaults)
- [x] End-to-end local demo: started a container with `:latest` tagged to the old 0.0.2 digest, Watchtower polled, detected `matches=false`, pulled registry `:latest` (0.0.3), recreated the container, removed old image via `--cleanup` — full cycle in ~2s
- [ ] Manual browser verification on other browsers (tested in Chrome)


<img width="2446" height="654" alt="image" src="https://github.com/user-attachments/assets/63285417-21ac-4080-9b76-d0e5fe8f3e7d" />
