### PR TITLE
entrypoint: restore libfreetype.so.6 link with copy fallback

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,6 +70,17 @@ if [ "$NEEDS_INSTALL" = true ]; then
     echo "RoonServer installed successfully."
 fi
 
+# libharfbuzz.so links against libfreetype.so.6 but the bundled lib has no
+# soname suffix. Prefer a symlink; fall back to a copy on host filesystems
+# that reject symlinks on the /Roon bind mount (e.g. CIFS without mfsymlinks).
+# Runs on every start so existing volumes from images that omitted the alias,
+# and any self-update that replaces Appliance/, still get a working alias.
+FREETYPE_SRC="${ROON_APP_DIR}/RoonServer/Appliance/libfreetype.so"
+FREETYPE_DST="${ROON_APP_DIR}/RoonServer/Appliance/libfreetype.so.6"
+if [ -f "$FREETYPE_SRC" ] && [ ! -e "$FREETYPE_DST" ]; then
+    ln -s "$FREETYPE_SRC" "$FREETYPE_DST" 2>/dev/null || cp "$FREETYPE_SRC" "$FREETYPE_DST"
+fi
+
 # Log versions at startup
 echo "Image:   $(cat /etc/roon-image-version 2>/dev/null || echo 'unknown')"
 echo "Branch: $ROON_INSTALL_BRANCH"


### PR DESCRIPTION
## Summary
- Restores the `libfreetype.so` → `libfreetype.so.6` alias that was removed in c468547
- Uses `ln -s` when permitted, falls back to `cp` on host filesystems that reject symlinks through the `/Roon` bind mount

## Background
Reports of:
\`\`\`
ln: failed to create symbolic link '/Roon/app/RoonServer/Appliance/libfreetype.so.6': Operation not permitted
\`\`\`
The bundled RoonServer tarball ships `libfreetype.so` without a soname suffix, while `libharfbuzz.so` in the same directory has a DT_NEEDED entry for `libfreetype.so.6`. Without the alias, the dynamic linker can't resolve it.

The original fix used `ln -sf` unconditionally. That works on ext4/xfs/btrfs hosts but returns EPERM when `/Roon` is backed by a filesystem that disallows symlink creation (CIFS without \`mfsymlinks\`, some FUSE/NAS overlays, Docker-on-Windows WSL2 9p passthroughs). Falling back to \`cp\` costs ~1 MB but guarantees the alias exists on every supported platform.

## Test plan
- [ ] Fresh install on ext4 host — verify `libfreetype.so.6` is a symlink
- [ ] Fresh install on a CIFS-mounted `/Roon` without mfsymlinks — verify `libfreetype.so.6` is a regular file and RoonServer starts
- [ ] RoonServer launches without `libfreetype.so.6` loader errors in either case