### PR TITLE
Install libfreetype6 in image, drop entrypoint symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,13 @@ LABEL org.opencontainers.image.licenses="Proprietary"
 #   tzdata          — IANA timezone data for TZ environment variable
 #   libicu76        — .NET globalization (Debian Trixie specific)
 #   libasound2t64   — ALSA audio, required by libraatmanager.so
+#   libfreetype6    — provides libfreetype.so.6 soname that bundled libharfbuzz links against
 #   cifs-utils      — SMB/CIFS network share mounting
 #   ca-certificates — HTTPS for streaming services and cloud APIs
 RUN apt-get update \
  && apt-get -y install --no-install-recommends \
     bash curl xz-utils bzip2 tzdata libicu76 \
-    libasound2t64 cifs-utils ca-certificates \
+    libasound2t64 libfreetype6 cifs-utils ca-certificates \
  && (chmod u-s /usr/sbin/mount.cifs 2>/dev/null || true) \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /var/log/apt /var/log/dpkg.log \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,17 +70,6 @@ if [ "$NEEDS_INSTALL" = true ]; then
     echo "RoonServer installed successfully."
 fi
 
-# libharfbuzz.so links against libfreetype.so.6 but the bundled lib has no
-# soname suffix. Prefer a symlink; fall back to a copy on host filesystems
-# that reject symlinks on the /Roon bind mount (e.g. CIFS without mfsymlinks).
-# Runs on every start so existing volumes from images that omitted the alias,
-# and any self-update that replaces Appliance/, still get a working alias.
-FREETYPE_SRC="${ROON_APP_DIR}/RoonServer/Appliance/libfreetype.so"
-FREETYPE_DST="${ROON_APP_DIR}/RoonServer/Appliance/libfreetype.so.6"
-if [ -f "$FREETYPE_SRC" ] && [ ! -e "$FREETYPE_DST" ]; then
-    ln -s "$FREETYPE_SRC" "$FREETYPE_DST" 2>/dev/null || cp "$FREETYPE_SRC" "$FREETYPE_DST"
-fi
-
 # Log versions at startup
 echo "Image:   $(cat /etc/roon-image-version 2>/dev/null || echo 'unknown')"
 echo "Branch: $ROON_INSTALL_BRANCH"


### PR DESCRIPTION
## Summary
- Add `libfreetype6` to the apt install in the Dockerfile so `libfreetype.so.6` resolves system-wide via `ld.so` cache.
- Remove the entrypoint's runtime symlink/copy workaround — no longer needed once the soname is available in `/usr/lib/x86_64-linux-gnu/`.

## Why
`libharfbuzz` in `RoonServer/Appliance/` has a `DT_NEEDED libfreetype.so.6`, but the bundled freetype in that directory ships without the soname suffix. The previous fix created the missing alias at startup (symlink, with a copy fallback for CIFS mounts that reject symlinks). Installing the Debian package is a cleaner fix — it eliminates the mount-filesystem edge cases and means freetype CVEs get picked up on image rebuild.

## Size impact
Measured via `docker image inspect`:
- Before: 97,275,474 bytes
- After:  97,828,822 bytes
- **Delta: +541 KB**

Two packages added (`libfreetype6`, `libpng16-16t64` as a transitive dep). All other runtime deps were already present.

## Test plan
- [x] `docker build` succeeds
- [x] `ldconfig -p` inside image shows `libfreetype.so.6 => /lib/x86_64-linux-gnu/libfreetype.so.6`
- [x] `tests/smoke.sh` — 24/24 pass
- [ ] `tests/runtime.sh` — exercises the actual harfbuzz→freetype load path at RoonServer startup (not run locally; recommended before merge)