### PR TITLE
Add UGREEN NAS platform preset

### DIFF
--- a/configurator/e2e/configurator.spec.ts
+++ b/configurator/e2e/configurator.spec.ts
@@ -31,7 +31,7 @@ test.describe('Initial state', () => {
     const values = await page
       .locator('#platform-select option')
       .evaluateAll((els) => els.map((e) => (e as HTMLOptionElement).value));
-    expect(values).toEqual(['qnap', 'synology', 'unraid', 'truenas', 'linux', 'custom']);
+    expect(values).toEqual(['qnap', 'synology', 'unraid', 'truenas', 'ugreen', 'linux', 'custom']);
   });
 
   test('Copy and Download are enabled with no input errors', async ({ page }) => {

--- a/configurator/public/platforms/index.json
+++ b/configurator/public/platforms/index.json
@@ -1,1 +1,1 @@
-["qnap", "synology", "unraid", "truenas", "linux", "custom"]
+["qnap", "synology", "unraid", "truenas", "ugreen", "linux", "custom"]

--- a/configurator/public/platforms/ugreen.json
+++ b/configurator/public/platforms/ugreen.json
@@ -1,0 +1,10 @@
+{
+  "id": "ugreen",
+  "label": "UGREEN",
+  "roon": "/volume1/docker/roon",
+  "music": "/volume1/Music",
+  "backup": "/volume1/roon-backups",
+  "prefix": "/volume1/",
+  "hint": "Paths set for UGREEN UGOS Pro (Container Manager). The default Music share is /volume1/Music (capital M). Use Docker network mode 'host' — bridged breaks Roon discovery.",
+  "rootPattern": "^/volume"
+}


### PR DESCRIPTION
## Summary

Adds UGREEN (UGOS Pro / Container Manager) to the configurator's platform dropdown with researched, community-validated defaults.

Closes #16.

## Defaults

| Field | Value | Why |
|---|---|---|
| `roon` | `/volume1/docker/roon` | Matches the Marius Hosting / community Docker convention used across UGREEN guides — UGOS Pro ships Container Manager with `/volume1/docker/<app>` as the de facto layout |
| `music` | `/volume1/Music` | UGOS Pro auto-creates a `Music` shared folder (capital M) on initial setup. Linux underneath is case-sensitive, so capitalization matters |
| `backup` | `/volume1/roon-backups` | UGREEN community has no standard convention; mirrors the Synology default |
| `prefix` | `/volume1/` | Synology-style volume namespace |
| `rootPattern` | `^/volume` | Broader than Synology's `^/volume\d+/` so `/volumeUSB1/usbshare/...` external-drive paths don't false-positive a warning |
| `userOverride` | (not set) | UGREEN Container Manager honors the image's default user — no `0:0` workaround needed |

## Hint copy

> Paths set for UGREEN UGOS Pro (Container Manager). The default Music share is /volume1/Music (capital M). Use Docker network mode 'host' — bridged breaks Roon discovery.

The `network_mode: host` callout is deliberate: it's the single most common UGREEN-specific support topic in the Roon Community for Docker setups (bridged mode silently breaks mDNS/SSDP).

## Position in dropdown

`index.json` order: `qnap, synology, unraid, truenas, ugreen, linux, custom` — appended between `truenas` and the `linux`/`custom` tail so existing platform ordering is preserved.

## Sources backing the choices

- [UGOS Pro setup, default `/volume1` storage location](https://needtoknowit.com.au/blog/ugreen-ugos-pro-setup-guide/)
- [Marius Hosting: UGREEN NAS Docker category index](https://mariushosting.com/category/ugreen-nas-docker/) (Synology-style `/volume1/docker/<app>` convention)
- [UGREEN official: Music Library Settings](https://ugreen7943.zendesk.com/hc/en-us/articles/11103361971215-Music-Library-Settings) (default `Music` share, capitalized)
- [Roon Labs Community: Roon on UGREEN NAS?](https://community.roonlabs.com/t/roon-on-ugreen-nas/288318) (network mode + Docker walkthroughs)

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 121/121 (platforms tests auto-discover the new JSON and validate it against `schema.json`)
- [x] `npm run test:e2e` — 23/23 (dropdown-order test updated to include `ugreen`)
- [ ] CI: build + tests + Pages deploy on merge