### PR TITLE
Fix in-container upgrade failures by patching start.sh tar flags

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,9 +139,14 @@ fi
 # the unpatched upstream version — gets re-patched on the next restart.
 
 START_SH="${ROON_APP_DIR}/RoonServer/start.sh"
-if [ -f "$START_SH" ] && ! grep -q -- "--no-same-owner" "$START_SH"; then
+# Guard checks for BOTH flags so a partial upstream fix (e.g., owner added
+# but not permissions) still triggers the full patch attempt. Post-sed we
+# also verify both flags are present before logging success.
+if [ -f "$START_SH" ] && ! { grep -q -- "--no-same-owner" "$START_SH" \
+     && grep -q -- "--no-same-permissions" "$START_SH"; }; then
     if sed -i 's|tar xf "$PKG"|tar xf --no-same-owner --no-same-permissions "$PKG"|' "$START_SH" \
-       && grep -q -- "--no-same-owner" "$START_SH"; then
+       && grep -q -- "--no-same-owner" "$START_SH" \
+       && grep -q -- "--no-same-permissions" "$START_SH"; then
         echo "Patched RoonServer/start.sh for in-container update compatibility."
     fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,6 +119,33 @@ if [ "$NEEDS_INSTALL" = true ]; then
     echo "RoonServer installed successfully."
 fi
 
+# --- Patch start.sh for in-container update durability ---------------------
+# RoonServer's start.sh handles in-container upgrades by extracting a new
+# build tarball into RoonServer/.update.tmp/. The bundled script uses bare
+# `tar xf "$PKG"` (no --no-same-owner / --no-same-permissions), and the
+# build tarballs store files as uid 1001 (the Azure Pipelines build agent).
+# That combination fails on hosts with restricted chown semantics — userns-
+# remapped Docker daemons, NFS mounts with root_squash, TrueNAS bind
+# mounts with strict ACLs — because tar tries to chown extracted files
+# to a uid the host filesystem rejects, exits non-zero, and start.sh's
+# `|| doerror` catches the failure as "ERROR: failed to tar xf $PKG".
+# Result: initial install succeeds (entrypoint extract uses the right
+# flags); auto-updates silently fail.
+#
+# Fix the running on-disk start.sh to mirror our entrypoint extract flags.
+# Idempotent: skip when the flag is already present (avoids double-patches
+# on restart, and makes upstream's eventual fix a no-op here). Re-runs on
+# every container start so each upgrade — which replaces start.sh with
+# the unpatched upstream version — gets re-patched on the next restart.
+
+START_SH="${ROON_APP_DIR}/RoonServer/start.sh"
+if [ -f "$START_SH" ] && ! grep -q -- "--no-same-owner" "$START_SH"; then
+    if sed -i 's|tar xf "$PKG"|tar xf --no-same-owner --no-same-permissions "$PKG"|' "$START_SH" \
+       && grep -q -- "--no-same-owner" "$START_SH"; then
+        echo "Patched RoonServer/start.sh for in-container update compatibility."
+    fi
+fi
+
 # --- Final state log --------------------------------------------------------
 # Line format is contract-ish: runtime tests grep for "^Branch: production"
 # and "^Branch: earlyaccess". Don't change the prefix or spacing without

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -254,6 +254,74 @@ check "multi-line VERSION: last line wins (detects production)" \
 check "image has no USER directive (runs as root)" \
     sh -c '[ -z "$(docker inspect --format "{{.Config.User}}" "$1")" ]' _ "$IMAGE"
 
+# In-container update compatibility: entrypoint must patch start.sh's bare
+# `tar xf` to use --no-same-owner --no-same-permissions, otherwise upgrades
+# fail on userns-remap / NFS-root_squash / strict-ACL hosts because tar
+# tries to chown extracted files to the build-agent uid (1001) and exits
+# non-zero on chown failure.
+#
+# Pre-seed a fake RoonServer install with start.sh containing the upstream
+# bare-tar pattern, plus a Server/RoonServer launcher and VERSION file so
+# the entrypoint takes the "no reinstall needed" path. Replace the
+# entrypoint's exec target with `:` (the no-op shell builtin) by also
+# providing a fake start.sh that just exits — but we want to inspect
+# start.sh after the patch step, so we use --entrypoint sh to bypass
+# entrypoint.sh entirely on the second run and just read the file.
+PATCH_TMP=$(mktemp -d)
+docker run --rm --entrypoint sh -v "$PATCH_TMP:/Roon" "$IMAGE" -c '
+mkdir -p /Roon/app/RoonServer/Server
+cat > /Roon/app/RoonServer/start.sh <<'\''EOF'\''
+#!/bin/bash
+if [ "$1" = "--update" ]; then
+    PKG="$2"; ROOTDIR="$3"
+    tar xf "$PKG" -C "$ROOTDIR/.update.tmp"
+fi
+exit 0
+EOF
+chmod +x /Roon/app/RoonServer/start.sh
+touch /Roon/app/RoonServer/Server/RoonServer
+printf "100\nproduction\n" > /Roon/app/RoonServer/VERSION
+' >/dev/null
+
+# Run the entrypoint — should detect existing install (no reinstall),
+# patch start.sh, then exec it (which exits 0 thanks to our fake script).
+PATCH_LOG=$(docker run --rm -e ROON_INSTALL_BRANCH=production -v "$PATCH_TMP:/Roon" "$IMAGE" 2>&1) || true
+
+# Read the (possibly-patched) start.sh from inside the container so the
+# test doesn't depend on host file-sharing config (Docker Desktop on
+# macOS doesn't share /var/folders by default).
+PATCHED_SH=$(docker run --rm --entrypoint cat -v "$PATCH_TMP:/Roon" "$IMAGE" /Roon/app/RoonServer/start.sh 2>&1)
+rm -rf "$PATCH_TMP" 2>/dev/null || true
+
+check "start.sh patch: tar invocation gets --no-same-owner + --no-same-permissions" \
+    sh -c 'echo "$1" | grep -qF "tar xf --no-same-owner --no-same-permissions \"\$PKG\""' _ "$PATCHED_SH"
+check "start.sh patch: idempotent (only one set of flags after patching)" \
+    sh -c '[ "$(echo "$1" | grep -c -- --no-same-owner)" -eq 1 ]' _ "$PATCHED_SH"
+check "start.sh patch: log message is emitted on patching" \
+    sh -c 'echo "$1" | grep -q "Patched RoonServer/start.sh"' _ "$PATCH_LOG"
+
+# Idempotency check on a second run: PATCH_TMP was deleted, so re-seed
+# with an already-patched start.sh and verify the entrypoint is a no-op.
+PATCH_TMP2=$(mktemp -d)
+docker run --rm --entrypoint sh -v "$PATCH_TMP2:/Roon" "$IMAGE" -c '
+mkdir -p /Roon/app/RoonServer/Server
+cat > /Roon/app/RoonServer/start.sh <<'\''EOF'\''
+#!/bin/bash
+if [ "$1" = "--update" ]; then
+    tar xf --no-same-owner --no-same-permissions "$PKG" -C "$ROOTDIR/.update.tmp"
+fi
+exit 0
+EOF
+chmod +x /Roon/app/RoonServer/start.sh
+touch /Roon/app/RoonServer/Server/RoonServer
+printf "100\nproduction\n" > /Roon/app/RoonServer/VERSION
+' >/dev/null
+PATCH2_LOG=$(docker run --rm -e ROON_INSTALL_BRANCH=production -v "$PATCH_TMP2:/Roon" "$IMAGE" 2>&1) || true
+rm -rf "$PATCH_TMP2" 2>/dev/null || true
+
+check "start.sh patch: skipped (no log) when --no-same-owner already present" \
+    sh -c '! echo "$1" | grep -q "Patched RoonServer/start.sh"' _ "$PATCH2_LOG"
+
 # Startup banner is always emitted (regardless of branch resolution outcome)
 check "startup banner always logged" \
     sh -c 'echo "$1" | grep -q "^Roon Docker image "' _ "$UNSET_OUTPUT"

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -316,10 +316,15 @@ chmod +x /Roon/app/RoonServer/start.sh
 touch /Roon/app/RoonServer/Server/RoonServer
 printf "100\nproduction\n" > /Roon/app/RoonServer/VERSION
 ' >/dev/null
-PATCH2_LOG=$(docker run --rm -e ROON_INSTALL_BRANCH=production -v "$PATCH_TMP2:/Roon" "$IMAGE" 2>&1) || true
+PATCH2_EXIT=0
+PATCH2_LOG=$(docker run --rm -e ROON_INSTALL_BRANCH=production -v "$PATCH_TMP2:/Roon" "$IMAGE" 2>&1) || PATCH2_EXIT=$?
 rm -rf "$PATCH_TMP2" 2>/dev/null || true
 
-check "start.sh patch: skipped (no log) when --no-same-owner already present" \
+# Guard the negative assertion below: if the container failed to start
+# at all, the "no log" assertion would pass for the wrong reason.
+check "start.sh patch: idempotent run exits cleanly" \
+    test "$PATCH2_EXIT" -eq 0
+check "start.sh patch: skipped (no log) when both flags already present" \
     sh -c '! echo "$1" | grep -q "Patched RoonServer/start.sh"' _ "$PATCH2_LOG"
 
 # Startup banner is always emitted (regardless of branch resolution outcome)


### PR DESCRIPTION
## Summary

Users on hosts with restricted-chown semantics (userns-remap Docker daemons, NFS bind mounts with `root_squash`, TrueNAS / Synology bind mounts with strict ACLs) report that **in-container Roon Server upgrades fail silently**, leaving them stuck on whatever version was installed at first start. Initial install works fine.

The reporter on a recent support ticket nailed the cause: `entrypoint.sh` extracts with `tar xjf ... --no-same-permissions --no-same-owner`, but RoonServer's bundled `start.sh` (which handles in-container upgrades) uses bare `tar xf "$PKG"`. The build tarball stores files as `vsts_azpcontainer:vsts_azpcontainer` (uid `1001`, the Azure Pipelines build agent). When start.sh runs as root in a container whose host filesystem rejects `chown 1001:1001`, tar exits non-zero, start.sh's `|| doerror` reports `"ERROR: failed to tar xf $PKG"`, and the upgrade aborts.

## Mechanism (verified)

| Host setup | Initial install (`entrypoint.sh`) | Upgrade (`start.sh`) |
|---|---|---|
| Local ext4/xfs, no remapping | ✓ — `--no-same-owner` makes tar use container's effective uid | ✓ — root can chown to anything |
| **userns-remap Docker daemon** | ✓ — `--no-same-owner` sidesteps the chown | ✗ — bare `tar xf` tries `chown 1001` outside the userns mapping → EPERM → exit non-zero |
| **NFS root_squash** | ✓ | ✗ — same chown rejection |
| **TrueNAS / Synology strict ACL** | ✓ | ✗ — same |

Confirmed by extracting the upstream tarball in a roonserver:1.0.6 container and inspecting `tar tjvf --numeric-owner` output (uid 1001) and `start.sh:21` (bare `tar xf`).

## What this PR does

`entrypoint.sh` now patches `RoonServer/start.sh` after the install block to inject `--no-same-owner --no-same-permissions` into its tar invocation. The patch is:

- **Idempotent** — guarded by `! grep -q -- "--no-same-owner"`, so it skips when already applied (own past run, or upstream's eventual fix).
- **Safe under upstream evolution** — if start.sh's pattern changes, sed simply doesn't substitute and the patch silently does nothing (the existing `|| doerror` would surface a new failure if any). The grep guard covers both the "already patched" case and "upstream now has the flag".
- **Self-healing across upgrades** — every successful in-container upgrade replaces start.sh with a fresh upstream copy. Next container restart re-runs the entrypoint and re-patches.

The proper fix is upstream — `start.sh` should match `entrypoint.sh`'s flags. This PR is the in-image workaround until that lands.

## Test plan

- [x] `tests/smoke.sh` extended (56 → 60 checks):
  - patches the upstream-shape `tar xf "$PKG"` correctly
  - inserts exactly one set of flags (no double-application)
  - emits the "Patched RoonServer/start.sh" log line
  - skips silently when the flag is already present
- [x] All 60 smoke + 37 runtime tests green locally on `roonserver:test` build