### PR TITLE
configurator: colocate Synology backup default under /volume1/docker

### DIFF
--- a/configurator/e2e/configurator.spec.ts
+++ b/configurator/e2e/configurator.spec.ts
@@ -45,7 +45,7 @@ test.describe('Platform switching', () => {
     await page.locator('#platform-select').selectOption('synology');
     await expect(page.locator('#vol-roon')).toHaveValue('/volume1/docker/roon');
     await expect(page.locator('#vol-music')).toHaveValue('/volume1/music');
-    await expect(page.locator('#vol-backup')).toHaveValue('/volume1/roon-backups');
+    await expect(page.locator('#vol-backup')).toHaveValue('/volume1/docker/roon-backups');
     expect(await getOutput(page)).toContain('- /volume1/music:/Music');
   });
 });

--- a/configurator/public/platforms/synology.json
+++ b/configurator/public/platforms/synology.json
@@ -3,7 +3,7 @@
   "label": "Synology",
   "roon": "/volume1/docker/roon",
   "music": "/volume1/music",
-  "backup": "/volume1/roon-backups",
+  "backup": "/volume1/docker/roon-backups",
   "prefix": "/volume1/",
   "hint": "Paths set for Synology DSM. Adjust volume1 if needed.",
   "rootPattern": "^/volume\\d+/"

--- a/configurator/src/urlState.test.ts
+++ b/configurator/src/urlState.test.ts
@@ -16,7 +16,7 @@ const platforms: PlatformMap = {
     id: 'synology', label: 'Synology',
     roon: '/volume1/docker/roon',
     music: '/volume1/music',
-    backup: '/volume1/roon-backups',
+    backup: '/volume1/docker/roon-backups',
     prefix: '/volume1/',
     hint: '',
     rootPattern: '^/volume\\d+/',
@@ -66,7 +66,7 @@ describe('encode', () => {
     const cfg = baseConfig({
       volRoon: '/volume1/docker/roon',
       volMusic: '/volume1/music',
-      volBackup: '/volume1/roon-backups',
+      volBackup: '/volume1/docker/roon-backups',
     });
     const params = encode(cfg, 'synology', platforms, 'qnap');
     expect(params.get('p')).toBe('synology');


### PR DESCRIPTION
## Summary
- Synology default for `backup` was `/volume1/roon-backups`, but `roon` lived at `/volume1/docker/roon` — inconsistent within the platform and out of step with QNAP, which keeps both under `/share/Container/`.
- Moves the Synology backup default to `/volume1/docker/roon-backups` so generated compose output groups Roon's app data and backups together.
- Updates the unit test fixture in `urlState.test.ts` and the Playwright assertion in `configurator.spec.ts` that snapshot the default.

## Test plan
- [x] `npx vitest run` (119/119 passing)
- [ ] `npx playwright test` to confirm the e2e platform-switching assertion
- [ ] Manual: load configurator, select Synology, verify `vol-backup` populates `/volume1/docker/roon-backups` and the rendered compose output reflects it