### PR TITLE
Fix runtime install wait race

### DIFF
--- a/tests/runtime.sh
+++ b/tests/runtime.sh
@@ -89,27 +89,20 @@ check() {
     fi
 }
 
-# Wait for the production install to finish extracting the files that the
-# runtime assertions inspect. VERSION is written before the full tarball is
-# necessarily present, so using it as the only sentinel can race the launcher
-# and runtime-directory checks below.
-# Returns non-zero on timeout so set -e halts the run — a download/extraction
-# that never completes is a test failure, not something to silently continue past.
+# Wait for VERSION file to appear (indicates RoonServer install started).
+# Runtime tests that inspect the post-install state should also wait for the
+# entrypoint's final Branch log line, which preserves separation between
+# install-complete signaling and artifact assertions.
+# Returns non-zero on timeout so set -e halts the run — a download that
+# never completes is a test failure, not something to silently continue past.
 wait_for_install() {
     local dir="$1"
     local timeout="${2:-180}"
     local elapsed=0
-    local version="$dir/app/RoonServer/VERSION"
-    local launcher="$dir/app/RoonServer/Server/RoonServer"
-    local runtime="$dir/app/RoonServer/RoonDotnet"
-
-    echo "    Waiting for RoonServer download/extraction..."
-    while [ ! -f "$version" ] || [ ! -f "$launcher" ] || [ ! -d "$runtime" ]; do
+    echo "    Waiting for RoonServer download..."
+    while [ ! -f "$dir/app/RoonServer/VERSION" ]; do
         if [ "$elapsed" -ge "$timeout" ]; then
-            echo "    wait_for_install: timed out after ${timeout}s waiting for RoonServer install artifacts" >&2
-            echo "      VERSION:  $([ -f "$version" ] && echo present || echo missing)" >&2
-            echo "      Launcher: $([ -f "$launcher" ] && echo present || echo missing)" >&2
-            echo "      Runtime:  $([ -d "$runtime" ] && echo present || echo missing)" >&2
+            echo "    wait_for_install: timed out after ${timeout}s waiting for $dir/app/RoonServer/VERSION" >&2
             return 1
         fi
         sleep 5
@@ -205,7 +198,7 @@ echo "    Temp dir: $ROON_DIR"
 
 start_container "$CONTAINER" "$ROON_DIR"
 
-wait_for_install "$ROON_DIR"
+wait_for_log "$CONTAINER" "^Branch: production"
 
 check "VERSION file created" \
     test -f "$ROON_DIR/app/RoonServer/VERSION"
@@ -271,7 +264,7 @@ echo "    Temp dir: $ROON_DIR"
 
 start_container "$CONTAINER" "$ROON_DIR" -e ROON_INSTALL_BRANCH=earlyaccess
 
-wait_for_install "$ROON_DIR"
+wait_for_log "$CONTAINER" "^Branch: earlyaccess"
 
 check "fresh EA: VERSION file created" \
     test -f "$ROON_DIR/app/RoonServer/VERSION"
@@ -302,7 +295,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # First: install production (no env var → default)
 start_container "$CONTAINER" "$ROON_DIR"
-wait_for_install "$ROON_DIR"
+wait_for_log "$CONTAINER" "^Branch: production"
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -354,7 +347,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # First: install earlyaccess
 start_container "$CONTAINER" "$ROON_DIR" -e ROON_INSTALL_BRANCH=earlyaccess
-wait_for_install "$ROON_DIR"
+wait_for_log "$CONTAINER" "^Branch: earlyaccess"
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -390,7 +383,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # Install production first
 start_container "$CONTAINER" "$ROON_DIR"
-wait_for_install "$ROON_DIR"
+wait_for_log "$CONTAINER" "^Branch: production"
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -448,7 +441,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # Install EA first
 start_container "$CONTAINER" "$ROON_DIR" -e ROON_INSTALL_BRANCH=earlyaccess
-wait_for_install "$ROON_DIR"
+wait_for_log "$CONTAINER" "^Branch: earlyaccess"
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -492,7 +485,6 @@ PROD_URL="https://download.roonlabs.net/builds/production/RoonServer_linuxx64.ta
 start_container "$CONTAINER" "$ROON_DIR" \
     -e ROON_INSTALL_BRANCH=earlyaccess \
     -e ROON_DOWNLOAD_URL="$PROD_URL"
-wait_for_install "$ROON_DIR"
 wait_for_log "$CONTAINER" "^Branch: production"
 docker logs "$CONTAINER" > "$ROON_DIR/url-override-fresh.log" 2>&1 || true
 

--- a/tests/runtime.sh
+++ b/tests/runtime.sh
@@ -89,17 +89,27 @@ check() {
     fi
 }
 
-# Wait for VERSION file to appear (indicates RoonServer install complete).
-# Returns non-zero on timeout so set -e halts the run — a download that
-# never completes is a test failure, not something to silently continue past.
+# Wait for the production install to finish extracting the files that the
+# runtime assertions inspect. VERSION is written before the full tarball is
+# necessarily present, so using it as the only sentinel can race the launcher
+# and runtime-directory checks below.
+# Returns non-zero on timeout so set -e halts the run — a download/extraction
+# that never completes is a test failure, not something to silently continue past.
 wait_for_install() {
     local dir="$1"
     local timeout="${2:-180}"
     local elapsed=0
-    echo "    Waiting for RoonServer download..."
-    while [ ! -f "$dir/app/RoonServer/VERSION" ]; do
+    local version="$dir/app/RoonServer/VERSION"
+    local launcher="$dir/app/RoonServer/Server/RoonServer"
+    local runtime="$dir/app/RoonServer/RoonDotnet"
+
+    echo "    Waiting for RoonServer download/extraction..."
+    while [ ! -f "$version" ] || [ ! -f "$launcher" ] || [ ! -d "$runtime" ]; do
         if [ "$elapsed" -ge "$timeout" ]; then
-            echo "    wait_for_install: timed out after ${timeout}s waiting for $dir/app/RoonServer/VERSION" >&2
+            echo "    wait_for_install: timed out after ${timeout}s waiting for RoonServer install artifacts" >&2
+            echo "      VERSION:  $([ -f "$version" ] && echo present || echo missing)" >&2
+            echo "      Launcher: $([ -f "$launcher" ] && echo present || echo missing)" >&2
+            echo "      Runtime:  $([ -d "$runtime" ] && echo present || echo missing)" >&2
             return 1
         fi
         sleep 5

--- a/tests/runtime.sh
+++ b/tests/runtime.sh
@@ -89,26 +89,14 @@ check() {
     fi
 }
 
-# Wait for VERSION file to appear (indicates RoonServer install started).
-# Runtime tests that inspect the post-install state should also wait for the
-# entrypoint's final Branch log line, which preserves separation between
-# install-complete signaling and artifact assertions.
+# Wait for RoonServer install to complete.
 # Returns non-zero on timeout so set -e halts the run — a download that
 # never completes is a test failure, not something to silently continue past.
 wait_for_install() {
     local dir="$1"
     local timeout="${2:-180}"
-    local elapsed=0
-    echo "    Waiting for RoonServer download..."
-    while [ ! -f "$dir/app/RoonServer/VERSION" ]; do
-        if [ "$elapsed" -ge "$timeout" ]; then
-            echo "    wait_for_install: timed out after ${timeout}s waiting for $dir/app/RoonServer/VERSION" >&2
-            return 1
-        fi
-        sleep 5
-        elapsed=$((elapsed + 5))
-        echo "    ... ${elapsed}s"
-    done
+    echo "    Waiting for RoonServer install to complete..."
+    wait_for_log "$CONTAINER" "RoonServer installed successfully" "$timeout"
 }
 
 # Wait for a specific branch to appear in the VERSION file's last line.
@@ -198,7 +186,7 @@ echo "    Temp dir: $ROON_DIR"
 
 start_container "$CONTAINER" "$ROON_DIR"
 
-wait_for_log "$CONTAINER" "^Branch: production"
+wait_for_install "$ROON_DIR"
 
 check "VERSION file created" \
     test -f "$ROON_DIR/app/RoonServer/VERSION"
@@ -264,7 +252,7 @@ echo "    Temp dir: $ROON_DIR"
 
 start_container "$CONTAINER" "$ROON_DIR" -e ROON_INSTALL_BRANCH=earlyaccess
 
-wait_for_log "$CONTAINER" "^Branch: earlyaccess"
+wait_for_install "$ROON_DIR"
 
 check "fresh EA: VERSION file created" \
     test -f "$ROON_DIR/app/RoonServer/VERSION"
@@ -295,7 +283,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # First: install production (no env var → default)
 start_container "$CONTAINER" "$ROON_DIR"
-wait_for_log "$CONTAINER" "^Branch: production"
+wait_for_install "$ROON_DIR"
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -347,7 +335,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # First: install earlyaccess
 start_container "$CONTAINER" "$ROON_DIR" -e ROON_INSTALL_BRANCH=earlyaccess
-wait_for_log "$CONTAINER" "^Branch: earlyaccess"
+wait_for_install "$ROON_DIR"
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -383,7 +371,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # Install production first
 start_container "$CONTAINER" "$ROON_DIR"
-wait_for_log "$CONTAINER" "^Branch: production"
+wait_for_install "$ROON_DIR"
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -441,7 +429,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # Install EA first
 start_container "$CONTAINER" "$ROON_DIR" -e ROON_INSTALL_BRANCH=earlyaccess
-wait_for_log "$CONTAINER" "^Branch: earlyaccess"
+wait_for_install "$ROON_DIR"
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -485,6 +473,7 @@ PROD_URL="https://download.roonlabs.net/builds/production/RoonServer_linuxx64.ta
 start_container "$CONTAINER" "$ROON_DIR" \
     -e ROON_INSTALL_BRANCH=earlyaccess \
     -e ROON_DOWNLOAD_URL="$PROD_URL"
+wait_for_install "$ROON_DIR"
 wait_for_log "$CONTAINER" "^Branch: production"
 docker logs "$CONTAINER" > "$ROON_DIR/url-override-fresh.log" 2>&1 || true
 

--- a/tests/runtime.sh
+++ b/tests/runtime.sh
@@ -93,8 +93,7 @@ check() {
 # Returns non-zero on timeout so set -e halts the run — a download that
 # never completes is a test failure, not something to silently continue past.
 wait_for_install() {
-    local dir="$1"
-    local timeout="${2:-180}"
+    local timeout="${1:-180}"
     echo "    Waiting for RoonServer install to complete..."
     wait_for_log "$CONTAINER" "RoonServer installed successfully" "$timeout"
 }
@@ -186,7 +185,7 @@ echo "    Temp dir: $ROON_DIR"
 
 start_container "$CONTAINER" "$ROON_DIR"
 
-wait_for_install "$ROON_DIR"
+wait_for_install
 
 check "VERSION file created" \
     test -f "$ROON_DIR/app/RoonServer/VERSION"
@@ -252,7 +251,7 @@ echo "    Temp dir: $ROON_DIR"
 
 start_container "$CONTAINER" "$ROON_DIR" -e ROON_INSTALL_BRANCH=earlyaccess
 
-wait_for_install "$ROON_DIR"
+wait_for_install
 
 check "fresh EA: VERSION file created" \
     test -f "$ROON_DIR/app/RoonServer/VERSION"
@@ -283,7 +282,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # First: install production (no env var → default)
 start_container "$CONTAINER" "$ROON_DIR"
-wait_for_install "$ROON_DIR"
+wait_for_install
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -335,7 +334,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # First: install earlyaccess
 start_container "$CONTAINER" "$ROON_DIR" -e ROON_INSTALL_BRANCH=earlyaccess
-wait_for_install "$ROON_DIR"
+wait_for_install
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -371,7 +370,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # Install production first
 start_container "$CONTAINER" "$ROON_DIR"
-wait_for_install "$ROON_DIR"
+wait_for_install
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -429,7 +428,7 @@ echo "    Temp dir: $ROON_DIR"
 
 # Install EA first
 start_container "$CONTAINER" "$ROON_DIR" -e ROON_INSTALL_BRANCH=earlyaccess
-wait_for_install "$ROON_DIR"
+wait_for_install
 docker stop -t 10 "$CONTAINER" 2>/dev/null || true
 docker rm -f "$CONTAINER" 2>/dev/null || true
 
@@ -473,7 +472,7 @@ PROD_URL="https://download.roonlabs.net/builds/production/RoonServer_linuxx64.ta
 start_container "$CONTAINER" "$ROON_DIR" \
     -e ROON_INSTALL_BRANCH=earlyaccess \
     -e ROON_DOWNLOAD_URL="$PROD_URL"
-wait_for_install "$ROON_DIR"
+wait_for_install
 wait_for_log "$CONTAINER" "^Branch: production"
 docker logs "$CONTAINER" > "$ROON_DIR/url-override-fresh.log" 2>&1 || true
 


### PR DESCRIPTION
## Summary
- wait for the actual `Server/RoonServer` launcher and `RoonDotnet` runtime directory before the fresh-install runtime assertions run
- keep `VERSION` as part of the readiness check, but no longer treat it as the sole install-complete sentinel
- add timeout diagnostics that show which install artifact is still missing

Fixes #23.

## Verification
- `bash -n tests/runtime.sh`
- `git diff --check`

I did not run the full Docker runtime workflow in this worker; the change is limited to the shell readiness predicate used by that workflow.