### PR TITLE
Add procps to fix ps: command not found during self-update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,11 @@ LABEL org.opencontainers.image.licenses="Proprietary"
 #   libfreetype6    — provides libfreetype.so.6 soname that bundled libharfbuzz links against
 #   cifs-utils      — SMB/CIFS network share mounting
 #   ca-certificates — HTTPS for streaming services and cloud APIs
+#   procps          — provides ps, required by RoonServer's self-update script
 RUN apt-get update \
  && apt-get -y install --no-install-recommends \
     bash curl xz-utils bzip2 tzdata libicu76 \
-    libasound2t64 libfreetype6 cifs-utils ca-certificates \
+    libasound2t64 libfreetype6 cifs-utils ca-certificates procps \
  && (chmod u-s /usr/sbin/mount.cifs 2>/dev/null || true) \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /var/log/apt /var/log/dpkg.log \

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -40,6 +40,19 @@ for bin in bash curl bzip2 tar ffmpeg; do
         docker run --rm --entrypoint which "$IMAGE" "$bin"
 done
 
+# ps (procps) is a runtime contract: RoonServer's bundled self-update
+# launcher runs `ps -Awwo pid,args | grep '[R]AATServer' | awk ...` to
+# kill stale RAATServer processes. A missing procps silently breaks
+# updates (RRD-1551), so assert both the binary and that the pipeline runs.
+check "ps is available (procps — RoonServer self-update)" \
+    docker run --rm --entrypoint which "$IMAGE" ps
+
+# Exercise the exact flags the launcher uses. Checking ps's own exit code
+# (not the pipeline's) is deliberate: a missing/broken ps must fail here,
+# whereas the full pipeline's exit is awk's, which is 0 even when ps errors.
+check "ps self-update invocation runs (ps -Awwo pid,args)" \
+    docker run --rm --entrypoint ps "$IMAGE" -Awwo pid,args
+
 # FFmpeg is a static binary from johnvansickle.com — verify it actually
 # executes on this image's glibc/kernel ABI, not just that the file exists.
 check "ffmpeg runs (static binary ABI-compatible)" \


### PR DESCRIPTION
## Summary
- Adds the `procps` package to the RoonServer Docker image runtime dependencies, providing `ps`.
- Fixes the self-update failure where the stock RoonServer launcher aborted with `ps: command not found` (line 56) while killing stale `RAATServer` processes.

## Background
The bundled RoonServer launcher (downloaded at runtime, not part of this repo) runs:

```
for i in $(ps -Awwo pid,args | grep '[R]AATServer' | awk '{print $1}'); do kill -9 $i; done
```

The base `debian:trixie-slim` image has no `ps`, so the update flow failed. Since we don't control that script, we can't refactor it to `pkill` — the correct fix is to provide a real `ps`. The healthcheck continues to read `/proc` directly and does not depend on `procps`.

## Test plan
- [x] `docker build` succeeds with the change
- [x] `ps` resolves to `/usr/bin/ps` (procps-ng 4.0.4) in the built image
- [x] The exact update pipeline `ps -Awwo pid,args | grep '[R]AATServer' | awk '{print $1}'` runs with exit 0

Fixes RRD-1551